### PR TITLE
Fix NumberFormatException for unresolved property placeholders

### DIFF
--- a/quarkus/extensions/kogito-quarkus-extension-common/kogito-quarkus-common-deployment/src/main/java/org/kie/kogito/quarkus/common/deployment/KogitoQuarkusApplicationPropertiesProvider.java
+++ b/quarkus/extensions/kogito-quarkus-extension-common/kogito-quarkus-common-deployment/src/main/java/org/kie/kogito/quarkus/common/deployment/KogitoQuarkusApplicationPropertiesProvider.java
@@ -79,7 +79,12 @@ public class KogitoQuarkusApplicationPropertiesProvider implements KogitoApplica
 
     @Override
     public <T> Optional<T> getApplicationProperty(String property, Class<T> clazz) {
-        return Optional.ofNullable(convert(properties.getProperty(property), clazz));
+        String value = properties.getProperty(property);
+        // Return empty for unresolved placeholders to avoid conversion errors during build time
+        if (value != null && value.contains("${")) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(convert(value, clazz));
     }
 
     @Override

--- a/quarkus/extensions/kogito-quarkus-extension-common/kogito-quarkus-common-deployment/src/test/java/org/kie/kogito/quarkus/common/deployment/KogitoQuarkusApplicationPropertiesProviderTest.java
+++ b/quarkus/extensions/kogito-quarkus-extension-common/kogito-quarkus-common-deployment/src/test/java/org/kie/kogito/quarkus/common/deployment/KogitoQuarkusApplicationPropertiesProviderTest.java
@@ -82,4 +82,13 @@ class KogitoQuarkusApplicationPropertiesProviderTest {
         assertFalse(provider.getApplicationProperties().contains("test.key"));
     }
 
+    @Test
+    void testUnresolvedPlaceholderReturnsEmpty() {
+        // Test that unresolved placeholders return empty instead of throwing NumberFormatException
+        provider.setApplicationProperty("test.placeholder", "${quarkus.http.port:8080}");
+        assertFalse(provider.getApplicationProperty("test.placeholder", Integer.class).isPresent());
+        // String access should still work
+        assertEquals("${quarkus.http.port:8080}", provider.getApplicationProperty("test.placeholder").orElse(null));
+    }
+
 }


### PR DESCRIPTION
## Problem

The build fails in CI when building `kogito-examples` with the following error:

```
ProcessCodegenException: Invalid process: 'restfunctions.sw.json'. 
Found error: java.lang.NumberFormatException: For input string: "${quarkus.http.port:8080}"
```

This is caused by commit 8fe28da which changed `KogitoQuarkusApplicationPropertiesProvider` to eagerly load properties during construction. When `getApplicationProperty(property, Integer.class)` is called with a property containing an unresolved placeholder like `${quarkus.http.port:8080}`, it attempts to convert the literal string to an Integer, causing a NumberFormatException.

## Solution

This PR adds a check in `getApplicationProperty(String property, Class<T> clazz)` to detect unresolved placeholders (strings containing `${`) and return `Optional.empty()` instead of attempting conversion. This prevents build-time failures while preserving the ability to access the raw placeholder string via `getApplicationProperty(String property)`.

## Changes

- Modified `KogitoQuarkusApplicationPropertiesProvider.getApplicationProperty(String, Class<T>)` to check for unresolved placeholders
- Added test case `testUnresolvedPlaceholderReturnsEmpty()` to verify the fix

## Testing

The fix ensures that:
1. Unresolved placeholders return `Optional.empty()` for typed access
2. Raw string access still returns the placeholder value
3. Build-time code generation no longer fails with NumberFormatException

Fixes the build failure in `serverless-workflow-functions-quarkus` example.